### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,8 +16,8 @@ setWiperKEYWORD2
 getWiperKEYWORD2
 read	KEYWORD2
 write	KEYWORD2
-openCircuit KEYWORD2
-enableOutput KEYWORD2
+openCircuit	KEYWORD2
+enableOutput	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords